### PR TITLE
sync v-model value when editor changed.

### DIFF
--- a/vue-json-editor.vue
+++ b/vue-json-editor.vue
@@ -13,14 +13,17 @@
     props: ['value', 'showBtns'],
     watch: {
       value: function (newValue) {
-        this.editor.set(newValue)
+        if (!this.internalChange) {
+          this.editor.set(newValue)
+        }
       }
     },
     data () {
       return {
         editor: null,
         error: false,
-        json: this.value
+        json: this.value,
+        internalChange: false
       }
     },
     mounted () {
@@ -39,7 +42,11 @@
           if (!self.error) {
             self.json = json
             self.$emit('json-change', json)
+            self.internalChange = true
             self.$emit('input', json)
+            self.$nextTick(function () {
+              self.internalChange = false
+            })
           }
         }
       }

--- a/vue-json-editor.vue
+++ b/vue-json-editor.vue
@@ -11,6 +11,11 @@
 
   export default {
     props: ['value', 'showBtns'],
+    watch: {
+      value: function (newValue) {
+        this.editor.set(newValue)
+      }
+    },
     data () {
       return {
         editor: null,
@@ -34,6 +39,7 @@
           if (!self.error) {
             self.json = json
             self.$emit('json-change', json)
+            self.$emit('input', json)
           }
         }
       }


### PR DESCRIPTION
The component will only get the json value while mounted. But when the json editor's content changed. The parent value associated with `v-model` will not change. This request will fix this issue.