### PR TITLE
Make css styles scoped - don't change global styles

### DIFF
--- a/vue-json-editor.vue
+++ b/vue-json-editor.vue
@@ -66,7 +66,7 @@
   }
 </script>
 
-<style>
+<style scoped>
   .ace_line_group {
     text-align: left;
   }


### PR DESCRIPTION
The current css overrides the global style for `<code>` which causes problems - component styles should be scoped.