### PR TITLE
jsoneditor: Skip none value nodes

### DIFF
--- a/assets/jsoneditor.js
+++ b/assets/jsoneditor.js
@@ -10446,7 +10446,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    var innerText = '';
 
 	    for (var i = 0, iMax = childNodes.length; i < iMax; i++) {
-	      var child = childNodes[i];
+		  var child = childNodes[i];
+		  // Skip <style> and <script> elements and empty text nodes that are direct decentants of editor
+		  if (['STYLE', 'SCRIPT'].includes(child.tagName) || (child.nodeValue && !child.nodeValue.trim().length && element.isContentEditable)) continue;
 
 	      if (child.nodeName == 'DIV' || child.nodeName == 'P') {
 	        var prevChild = childNodes[i - 1];


### PR DESCRIPTION
Fixes a problem where larger text values get the value of whole subtree including styles and line breaks.
For example `481a36f5-e9ae-4d3b-b91e-fee87c0df5e3` turns into:
```
\n\n\n\n\n\np.p1 {margin: 0.0px 0.0px 0.0px 0.0px; font: 12.0px Monaco; color: #b3b3b3; background-color: #000000}\nspan.s1 {font-variant-ligatures: no-common-ligatures}\n\n\n\n481a36f5-e9ae-4d3b-b91e-fee87c0df5e3
```

You'll need to recompile the `min.js` version after this.